### PR TITLE
windows compatibility fixes in BazelQueryHelper#getJavaPackage:

### DIFF
--- a/com.salesforce.b2eclipse.jdt.ls/META-INF/MANIFEST.MF
+++ b/com.salesforce.b2eclipse.jdt.ls/META-INF/MANIFEST.MF
@@ -12,7 +12,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jdt.launching,
  com.google.gson;bundle-version="2.8.2",
  com.google.guava;bundle-version="27.1.0",
- org.eclipse.jdt.ls.core
+ org.eclipse.jdt.ls.core,
+ org.apache.commons.lang3;bundle-version="3.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: b2eclipse.jdt.ls
 Bundle-ActivationPolicy: lazy

--- a/com.salesforce.b2eclipse.jdt.ls/src/main/java/com/salesforce/b2eclipse/command/internal/BazelQueryHelper.java
+++ b/com.salesforce.b2eclipse.jdt.ls/src/main/java/com/salesforce/b2eclipse/command/internal/BazelQueryHelper.java
@@ -33,6 +33,9 @@ import com.salesforce.b2eclipse.abstractions.WorkProgressMonitor;
 import com.salesforce.b2eclipse.command.BazelCommandLineToolConfigurationException;
 import com.salesforce.b2eclipse.model.BazelBuildFileHelper;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.SystemUtils;
+
 /**
  * Helper that knows how to run bazel query commands.
  */
@@ -153,13 +156,12 @@ public class BazelQueryHelper {
         argBuilder.add("package");
         
         return bazelCommandExecutor.runBazelAndGetOutputLines(bazelWorkspaceRootDirectory, progressMonitor,
-            argBuilder.build(), (t) -> t.isEmpty() ? null : t);
+            argBuilder.build(), (t) -> StringUtils.trimToNull(t));
     }
     
     public synchronized List<String> getJavaPackages(File bazelWorkspaceRootDirectory, WorkProgressMonitor progressMonitor) throws IOException, InterruptedException, BazelCommandLineToolConfigurationException {
         
         ImmutableList.Builder<String> argBuilder = ImmutableList.builder();
-        final String osName = System.getProperty("os.name");
         StringBuilder javaProjectIndicators = new StringBuilder();
         javaProjectIndicators.append("kind('");
         javaProjectIndicators.append(String.join("|", BazelBuildFileHelper.JAVA_PROJECT_INDICATORS));
@@ -167,7 +169,7 @@ public class BazelQueryHelper {
         
         argBuilder.add("query");
         // 3 types of behavior: 1. Windows (command line and java.lang.Process), 2. non-Windows command line, 3. non-Windows java.lang.Process
-        if (osName != null && osName.toLowerCase().startsWith("win")) {
+        if (SystemUtils.IS_OS_WINDOWS) {
             argBuilder.add("\"" + javaProjectIndicators.toString() + "\"");
         } else {
             argBuilder.add(javaProjectIndicators.toString());
@@ -176,7 +178,7 @@ public class BazelQueryHelper {
         argBuilder.add("package");
         
         return bazelCommandExecutor.runBazelAndGetOutputLines(bazelWorkspaceRootDirectory, progressMonitor,
-            argBuilder.build(), (t) -> (t == null || t.trim().isEmpty()) ? null : t.trim());
+            argBuilder.build(), (t) -> StringUtils.trimToNull(t));
     }
 
 }

--- a/com.salesforce.b2eclipse.jdt.ls/src/main/java/com/salesforce/b2eclipse/command/internal/BazelQueryHelper.java
+++ b/com.salesforce.b2eclipse.jdt.ls/src/main/java/com/salesforce/b2eclipse/command/internal/BazelQueryHelper.java
@@ -159,14 +159,24 @@ public class BazelQueryHelper {
     public synchronized List<String> getJavaPackages(File bazelWorkspaceRootDirectory, WorkProgressMonitor progressMonitor) throws IOException, InterruptedException, BazelCommandLineToolConfigurationException {
         
         ImmutableList.Builder<String> argBuilder = ImmutableList.builder();
+        final String osName = System.getProperty("os.name");
+        StringBuilder javaProjectIndicators = new StringBuilder();
+        javaProjectIndicators.append("kind('");
+        javaProjectIndicators.append(String.join("|", BazelBuildFileHelper.JAVA_PROJECT_INDICATORS));
+        javaProjectIndicators.append("', //...)");
         
         argBuilder.add("query");
-        argBuilder.add("kind(\"" + String.join("|", BazelBuildFileHelper.JAVA_PROJECT_INDICATORS) + "\", //...)");
+        // 3 types of behavior: 1. Windows (command line and java.lang.Process), 2. non-Windows command line, 3. non-Windows java.lang.Process
+        if (osName != null && osName.toLowerCase().startsWith("win")) {
+            argBuilder.add("\"" + javaProjectIndicators.toString() + "\"");
+        } else {
+            argBuilder.add(javaProjectIndicators.toString());
+        }
         argBuilder.add("--output");
         argBuilder.add("package");
         
         return bazelCommandExecutor.runBazelAndGetOutputLines(bazelWorkspaceRootDirectory, progressMonitor,
-            argBuilder.build(), (t) -> t.isEmpty() ? null : t);
+            argBuilder.build(), (t) -> (t == null || t.trim().isEmpty()) ? null : t.trim());
     }
 
 }


### PR DESCRIPTION
# Related Issue
- Close #85 WinOS compatibility issues (test against large demo) 

# Additional Info
- fixed Windows platform compatibility issues: 
  1. Bazel query command
  2. result processing (trimming spaces)

